### PR TITLE
ci: build images on versions.yaml change

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,122 @@
+name: build-images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - versions.yaml
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Which system to build (hs|sn|media|teastore|all)"
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - hs
+          - sn
+          - media
+          - teastore
+
+jobs:
+  build:
+    name: build ${{ matrix.sys }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sys: [hs, sn, media, teastore]
+    concurrency:
+      group: build-images-${{ matrix.sys }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Decide whether to build
+        id: gate
+        env:
+          SYS: ${{ matrix.sys }}
+          DISPATCH_TARGET: ${{ github.event.inputs.target }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          should_run=0
+          reason=""
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$DISPATCH_TARGET" == "all" || "$DISPATCH_TARGET" == "$SYS" ]]; then
+              should_run=1
+              reason="workflow_dispatch target=$DISPATCH_TARGET"
+            else
+              reason="workflow_dispatch target=$DISPATCH_TARGET does not include $SYS"
+            fi
+          else
+            # Push event: only run if this system's line in versions.yaml changed.
+            if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+              if git diff --unified=0 HEAD^ HEAD -- versions.yaml \
+                  | grep -E "^[+-]${SYS}:" >/dev/null; then
+                should_run=1
+                reason="versions.yaml changed for $SYS"
+              else
+                reason="versions.yaml unchanged for $SYS"
+              fi
+            else
+              # No parent commit (initial commit / shallow miss): run to be safe.
+              should_run=1
+              reason="no parent commit available; building defensively"
+            fi
+          fi
+          echo "should_run=$should_run" >>"$GITHUB_OUTPUT"
+          echo "reason=$reason" >>"$GITHUB_OUTPUT"
+          echo "decision: should_run=$should_run ($reason)"
+
+      - name: Free disk
+        if: steps.gate.outputs.should_run == '1'
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/share/boost
+          sudo docker system prune -af
+          df -h /
+
+      - name: Set up Docker Buildx
+        if: steps.gate.outputs.should_run == '1'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: steps.gate.outputs.should_run == '1'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push images for ${{ matrix.sys }}
+        if: steps.gate.outputs.should_run == '1'
+        env:
+          SYS: ${{ matrix.sys }}
+        run: |
+          set -euo pipefail
+          bash tools/sync.sh "$SYS"
+
+      - name: Summarise pushed tags
+        if: steps.gate.outputs.should_run == '1'
+        env:
+          SYS: ${{ matrix.sys }}
+        run: |
+          set -euo pipefail
+          source tools/lib/common.sh
+          tag="$(tag_for "$SYS")"
+          {
+            echo "### ${SYS} pushed tags"
+            echo ""
+            echo "Tag: \`${tag}\`"
+            echo ""
+            bash tools/build-images.sh "$SYS" --verify-only 2>&1 \
+              | sed -n 's/^.* ok: \(.*\)  digest=\(.*\)$/- `\1` (\2)/p'
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Skipped
+        if: steps.gate.outputs.should_run != '1'
+        run: |
+          echo "Skipping ${{ matrix.sys }}: ${{ steps.gate.outputs.reason }}"

--- a/tools/README.md
+++ b/tools/README.md
@@ -27,7 +27,9 @@ bump the fork SHA there, not here.
 ## `versions.yaml`
 
 Single source of truth for which upstream commit SHA each system is
-pinned to. Bump a value here, then run the sync:
+pinned to. Bumping `versions.yaml` on `main` now triggers
+`.github/workflows/build-images.yml` — manual `sync.sh` is only needed
+for local debugging.
 
 ```bash
 tools/sync.sh hs        # one system


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-images.yml`: when `versions.yaml` changes on `main` (or via `workflow_dispatch`), a matrix job per system (`hs`, `sn`, `media`, `teastore`) runs `tools/sync.sh <sys>` so the LGU-fork images get rebuilt and pushed to `docker.io/opspai` automatically.
- Replaces the ssh-into-laptop-and-run-`tools/sync.sh`-by-hand workflow that bit us a few hours ago waiting for the LGU#54 BSP fix to land in our images.
- Tiny copy-edit in `tools/README.md` so the docs point at the workflow, not at manual `sync.sh`.

## Trigger semantics

- `push` to `main` with a path filter on `versions.yaml`. Each matrix leg additionally gates itself by `git diff HEAD^ HEAD -- versions.yaml`, only running if its own `^<sys>:` line changed in that commit. This means a single-line bump (e.g. just `hs:`) won't rebuild all four.
- `workflow_dispatch` with input `target` ∈ `{all, hs, sn, media, teastore}` (default `all`) for manual re-runs.
- `concurrency: build-images-<sys>` per matrix leg, so two simultaneous bumps queue per system rather than collide on the registry.

## Disk-prune note

GH Actions `ubuntu-latest` runners ship with ~14 GB free. DSB C++ builds (`sn`, `media`) historically OOM/fill disk, so the job starts by stripping `/usr/share/dotnet`, `/opt/ghc`, `/usr/local/lib/android`, `/usr/local/share/boost` and pruning Docker before any build.

## Other observations (NOT fixed in this PR — flagging only)

- `tools/lib/common.sh::docker_logged_in()` greps `~/.docker/config.json` for the `index.docker.io` key. After `docker/login-action@v3` runs, that file does have the entry, so the check passes — but the function dies hard on missing config rather than just warning. If we ever switch to OIDC / cred-helper-only, this will need rethinking.
- `versions.yaml` lets two systems share the same SHA (today both `sn` and `media` point at `9397c2e`). The per-system gate diffs the line by prefix, which is correct, but worth noting if anyone refactors the format.
- The summary step re-invokes `tools/build-images.sh --verify-only` to read back digests; this is one extra registry round-trip per system. Cheap enough to be worth the visibility, but if it gets noisy we can shave it.

## First test

Once this PR merges, the in-flight `versions.yaml` bump (`sn` + `media` → `9397c2e`, BSP fix from LGU#54) will be the first natural trigger. Order should be: merge this PR first, then the `versions.yaml` bump PR — the bump push will then auto-build `sn` and `media`.

## Test plan

- [ ] Merge this PR.
- [ ] Merge the in-flight `chore/bump-sn-media-bsp-fix` PR (sn+media → 9397c2e).
- [ ] Confirm the `build-images` workflow runs on the merge commit, that `hs` and `teastore` legs short-circuit (gate `should_run=0`), and that `sn` + `media` legs push the new tag.
- [ ] Verify `docker manifest inspect docker.io/opspai/social-network-microservices:<YYYYMMDD>-9397c2e` resolves.
- [ ] Smoke-test the dispatch path: Actions UI → run workflow with `target=hs` and confirm only the `hs` leg runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)