### PR TITLE
chore: bump sn+media to LGU master 9397c2e (BSP fix — aegis#236)

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -6,6 +6,6 @@
 # The chart for each of these systems lives in the fork's gh-pages
 # site, not in this repo — we only own the images.
 hs: 61074ea        # github.com/LGU-SE-Internal/DeathStarBench (hotelReservation)
-sn: 61074ea        # github.com/LGU-SE-Internal/DeathStarBench (socialNetwork)
-media: 61074ea     # github.com/LGU-SE-Internal/DeathStarBench (mediaMicroservices)
+sn: 9397c2e        # github.com/LGU-SE-Internal/DeathStarBench (socialNetwork)
+media: 9397c2e     # github.com/LGU-SE-Internal/DeathStarBench (mediaMicroservices)
 teastore: 2b3fd43  # github.com/LGU-SE-Internal/TeaStore


### PR DESCRIPTION
## Summary

- Bump `sn` and `media` SHAs in `versions.yaml` to `9397c2e` to track the LGU-SE-Internal/DeathStarBench master HEAD after [LGU PR #54 (BSP flush-on-shutdown fix)](https://github.com/LGU-SE-Internal/DeathStarBench/pull/54) merged.
- Built + pushed all 7 affected images under the unified tag `20260427-9397c2e` (verified on Docker Hub):
  - `opspai/social-network-microservices:20260427-9397c2e` (digest `sha256:1c7d9e39e7cd`)
  - `opspai/sn-openresty-thrift:20260427-9397c2e` (digest `sha256:f73472d02c7a`)
  - `opspai/media-frontend:20260427-9397c2e` (digest `sha256:422c0728e506`)
  - `opspai/socialnetwork-loader:20260427-9397c2e` (digest `sha256:e9ca39ec2858`)
  - `opspai/media-microservices:20260427-9397c2e` (digest `sha256:048bc7ff82f2`)
  - `opspai/media-nginx:20260427-9397c2e` (digest `sha256:ae2e454dc290`)
  - `opspai/mediamicroservices-loader:20260427-9397c2e` (digest `sha256:33ae43d3c7ff`)

## Why

Without the BSP fix, the OTel C++ SDK's BatchSpanProcessor drops the in-flight span batch on container shutdown, so post-fault traces near the chaos-experiment cleanup boundary are lost. The aegis fault-injection pipeline depends on those trailing spans to reconstruct the failure window. LGU PR #54 adds an explicit Shutdown() flush; this PR pulls that into our image set.

LGU's own socialnetwork-push.yaml and mediamicroservices-push.yaml (added in LGU PR #55) only publish the main service image. The auxiliary images (nginx-web-server, media-frontend, loaders) are still owned by us, hence tools/sync.sh is the canonical lock-step build path.

## Refs

- aegis tracking issue: aegis#236
- Upstream BSP fix: LGU-SE-Internal/DeathStarBench#54 (commit 9397c2e)
- Upstream CI workflow add: LGU-SE-Internal/DeathStarBench#55

hs (Go stack, OTel Go SDK has its own shutdown semantics) is unaffected and intentionally left at 61074ea.

## Build stats

- sn (4 images): ~48 min total — image 1 376s, image 2 (sn-openresty-thrift, the heavy BSP build) 1217s, image 3 (media-frontend) 1241s, image 4 (loader) 54s.
- media (3 images): ~12 min total — image 1 (media-microservices, BSP build) 656s, image 2 (media-nginx) 9s cached, image 3 (loader) 13s.

The big build is the openresty-thrift / media-microservices image — those depend on the OTel C++ SDK and rebuild gRPC + protobuf from source. Other images cached cleanly off prior `61074ea` layers since the BSP fix only touched the BSP `cc` files inside otelcpp, not the auxiliary Dockerfiles.

## Follow-up

aegis seed needs to bump `global.defaultImageVersion` for sn and media charts to `20260427-9397c2e` in a follow-up PR.

## Test plan

- [x] All 7 tags resolve on Docker Hub (verified via `https://hub.docker.com/v2/repositories/opspai/<image>/tags`)
- [ ] Smoke-test sn deployment on aegis kind cluster, inject one chaos, confirm last span batch lands in ClickHouse before workload teardown
- [ ] Same for media