### PR TITLE
fix(otel-demo-aegis): disable ALL ClusterRole-triggering presets for parallel installs (0.1.7)

### DIFF
--- a/charts/otel-demo-aegis/Chart.yaml
+++ b/charts/otel-demo-aegis/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-demo-aegis
 description: opentelemetry-demo wrapper for aegis. Keeps the demo's in-namespace collector, avoids cluster-scoped RBAC, and forwards OTLP to the cluster collector.
-version: 0.1.6
+version: 0.1.7
 appVersion: "2.2.0"
 dependencies:
 - name: opentelemetry-demo

--- a/charts/otel-demo-aegis/values.yaml
+++ b/charts/otel-demo-aegis/values.yaml
@@ -27,13 +27,34 @@ opentelemetry-demo:
   # lets the wrapper forward everything upstream over a single OTLP exporter.
   opentelemetry-collector:
     enabled: true
+    # Force-disable cluster-scoped RBAC creation for parallel-install safety.
+    # The opentelemetry-collector subchart's clusterrole.yaml renders if ANY
+    # of these are enabled: clusterRole.create OR presets.kubernetesAttributes
+    # OR presets.clusterMetrics OR presets.kubeletMetrics OR
+    # presets.kubernetesEvents OR presets.annotationDiscovery.{logs,metrics}.
+    # The opentelemetry-demo subchart's defaults turn several of these on, so
+    # disabling kubernetesAttributes alone is NOT enough — the ClusterRole
+    # `otel-collector` still gets rendered and the second parallel install
+    # into a sibling namespace fails with "ClusterRole exists and cannot be
+    # imported into the current release: invalid ownership metadata"
+    # (helm.sh/release-name mismatch). Disable every triggering knob below
+    # so multiple otel-demoN installs can coexist.
+    clusterRole:
+      create: false
     presets:
-      # Disable the kubernetesAttributes preset so the demo collector stays
-      # namespace-scoped and does not create ClusterRole/ClusterRoleBinding
-      # objects. App pods already inject k8s.pod.name + k8s.namespace.name, and
-      # the cluster collector performs the cluster-wide enrichment/export path.
       kubernetesAttributes:
         enabled: false
+      clusterMetrics:
+        enabled: false
+      kubeletMetrics:
+        enabled: false
+      kubernetesEvents:
+        enabled: false
+      annotationDiscovery:
+        logs:
+          enabled: false
+        metrics:
+          enabled: false
     # Replace the repo-local otel-demo collector config so the wrapper can drop
     # ClickHouse and export all signals to the cluster collector instead.
     alternateConfig:


### PR DESCRIPTION
## Why

The opentelemetry-collector subchart's \`templates/clusterrole.yaml\` renders if **any** of these are true:

\`\`\`
clusterRole.create
OR presets.kubernetesAttributes.enabled
OR presets.clusterMetrics.enabled
OR presets.kubeletMetrics.enabled
OR presets.kubernetesEvents.enabled
OR presets.annotationDiscovery.logs.enabled
OR presets.annotationDiscovery.metrics.enabled
\`\`\`

The opentelemetry-demo subchart's defaults turn several of these on (e.g. \`k8s_cluster\` + \`kubeletstats\` receivers in the rendered config). Our wrapper only disabled \`kubernetesAttributes\` (added by 39b58c2 Apr 23, preserved through the LGU snapshot sync 6a627c8), so a ClusterRole named \`otel-collector\` was still being rendered for every \`otel-demoN\` install.

Single-namespace installs hid the bug — only the first install landed cleanly. As soon as more than one namespace was installed in parallel, helm 3-way merge refused with:

\`\`\`
ClusterRole "otel-collector" exists and cannot be imported into the current release:
  invalid ownership metadata; annotation validation error:
    key "meta.helm.sh/release-name" must equal "otel-demo1": current value is "otel-demo0"
    key "meta.helm.sh/release-namespace" must equal "otel-demo1": current value is "otel-demo0"
\`\`\`

Live observation on byte-cluster (otel-demo loop): R1 submitted 12 traces, ns 1-11 all failed at RestartPedestal because ns 0 had created the cluster-scoped \`otel-collector\` ClusterRole + ClusterRoleBinding first.

## What

\`charts/otel-demo-aegis/values.yaml\` — under \`opentelemetry-demo.opentelemetry-collector\`:

- \`clusterRole.create: false\` (explicit, defense in depth)
- \`presets.kubernetesAttributes.enabled: false\` (was already there; kept)
- \`presets.clusterMetrics.enabled: false\` (NEW)
- \`presets.kubeletMetrics.enabled: false\` (NEW)
- \`presets.kubernetesEvents.enabled: false\` (NEW)
- \`presets.annotationDiscovery.logs.enabled: false\` (NEW)
- \`presets.annotationDiscovery.metrics.enabled: false\` (NEW)

App pods already inject \`k8s.pod.name\` + \`k8s.namespace.name\` so the in-namespace collector doesn't need k8sattributes; cross-namespace enrichment + leader-elected k8s receivers (\`k8s_cluster\`, \`kubeletstats\`, \`k8sobjects\`) live on the cluster otel-kube-stack collector instead.

Bumped chart version 0.1.6 → 0.1.7.

## Verification

\`\`\`
helm template t charts/otel-demo-aegis -n t --set global.clusterCollector.service=t \\
  | grep -c "kind: ClusterRole"
0
\`\`\`

Down from 2 (ClusterRole + ClusterRoleBinding) before the fix.

Already published to \`registry-1.docker.io/opspai/otel-demo-aegis:0.1.7\` and verified mirrored to \`pair-cn-shanghai.cr.volces.com/opspai/otel-demo-aegis:0.1.7\`. Pulling and using on byte-cluster after this PR merges + AegisLab seed bump (separate PR).

## Context

Identified during byte-cluster K=12 multi-loop campaign — otel-demo loop 100% blocked by parallel ClusterRole conflict for hours. ts and hs systems unaffected (different chart families).