### PR TITLE
fix(otel-demo-aegis): mirror busybox + kafka via opspai dockerhub

### DIFF
--- a/charts/otel-demo-aegis/Chart.yaml
+++ b/charts/otel-demo-aegis/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-demo-aegis
 description: opentelemetry-demo wrapper for aegis. Keeps the demo's in-namespace collector, avoids cluster-scoped RBAC, and forwards OTLP to the cluster collector.
-version: 0.1.7
+version: 0.1.8
 appVersion: "2.2.0"
 dependencies:
 - name: opentelemetry-demo

--- a/charts/otel-demo-aegis/values.yaml
+++ b/charts/otel-demo-aegis/values.yaml
@@ -5,6 +5,48 @@ global:
     service: otel-collector.otel.svc.cluster.local
 
 opentelemetry-demo:
+  # Mirror upstream images to opspai dockerhub so the volces auto-mirror
+  # (pair-cn-shanghai.cr.volces.com/opspai/*) can serve them on clusters
+  # that can't reach docker.io / ghcr.io directly. Without these overrides,
+  # busybox init containers stay in ImagePullBackOff and kafka never starts,
+  # which then keeps every wait-for-kafka init blocked forever.
+  components:
+    kafka:
+      imageOverride:
+        repository: docker.io/opspai/otel-demo-kafka
+        tag: "2.2.0"
+      initContainers: []
+    accounting:
+      initContainers:
+        - name: wait-for-kafka
+          image: docker.io/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+    cart:
+      initContainers:
+        - name: wait-for-valkey-cart
+          image: docker.io/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep 2; done;"]
+    checkout:
+      initContainers:
+        - name: wait-for-kafka
+          image: docker.io/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+    fraud-detection:
+      initContainers:
+        - name: wait-for-kafka
+          image: docker.io/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+    flagd:
+      initContainers:
+        - name: init-config
+          image: docker.io/opspai/busybox:latest
+          command: ["sh", "-c", "cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json"]
+          volumeMounts:
+            - mountPath: /config-ro
+              name: config-ro
+            - mountPath: /config-rw
+              name: config-rw
+
   # Keep pod + namespace identity on the emitted OTLP resources. The local demo
   # collector can enrich by connection metadata, and the upstream cluster
   # collector still uses these attributes when it rewrites service.namespace for

--- a/charts/otel-demo-aegis/values.yaml
+++ b/charts/otel-demo-aegis/values.yaml
@@ -69,6 +69,13 @@ opentelemetry-demo:
   # lets the wrapper forward everything upstream over a single OTLP exporter.
   opentelemetry-collector:
     enabled: true
+    # Run as a single Deployment, not a per-node DaemonSet. The cluster already
+    # runs `monitoring/opentelemetry-kube-stack-daemon` for host/kubelet/pod
+    # metrics + container logs; the only job of THIS in-namespace collector is
+    # to receive demo-app OTLP and forward to the cluster collector. A daemonset
+    # variant also collides on hostPort 4317/4318 with the cluster daemon and
+    # leaves every pod Pending (benchmark-charts#9).
+    mode: deployment
     # Force-disable cluster-scoped RBAC creation for parallel-install safety.
     # The opentelemetry-collector subchart's clusterrole.yaml renders if ANY
     # of these are enabled: clusterRole.create OR presets.kubernetesAttributes


### PR DESCRIPTION
## Summary
- byte-cluster nodes can't pull from docker.io / ghcr.io directly; the upstream demo's `busybox:latest` init containers (wait-for-kafka in accounting/cart/checkout/fraud-detection, init-config in flagd) and `ghcr.io/open-telemetry/demo:2.2.0-kafka` all stay in `ImagePullBackOff`.
- Pushed mirrors to `docker.io/opspai/busybox:latest` and `docker.io/opspai/otel-demo-kafka:2.2.0`; volces auto-mirror (`pair-cn-shanghai.cr.volces.com/opspai/*`) picks them up.
- Override per-component `imageOverride` (kafka) and `initContainers` (busybox-using components) to point at the opspai mirrors. Chart bumped 0.1.7 -> 0.1.8.

Paired bump in aegis: OperationsPAI/aegis seed `data.yaml` otel-demo `helm_config.version` 0.1.7 -> 0.1.8.

## Test plan
- [x] `helm template` renders all five overridden init containers + kafka image as `docker.io/opspai/*`
- [ ] Reinstall otel-demoN on byte-cluster, confirm wait-for-kafka and kafka pods reach `Running`