### PR TITLE
feat(otel-demo): add per-namespace collector sidecar

### DIFF
--- a/charts/otel-demo-aegis/Chart.lock
+++ b/charts/otel-demo-aegis/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: opentelemetry-demo
+  repository: ""
+  version: 0.40.7
+digest: sha256:f74b420d9664dd11974a9477030dc32ccf52969b5b86da7b600b7d7aae52553d
+generated: "2026-05-02T06:49:27.970042152+01:00"

--- a/charts/otel-demo-aegis/Chart.yaml
+++ b/charts/otel-demo-aegis/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-demo-aegis
 description: opentelemetry-demo wrapper for aegis. Keeps the demo's in-namespace collector, avoids cluster-scoped RBAC, and forwards OTLP to the cluster collector.
-version: 0.1.8
+version: 0.1.9
 appVersion: "2.2.0"
 dependencies:
 - name: opentelemetry-demo

--- a/charts/otel-demo-aegis/templates/otel-collector-configmap.yaml
+++ b/charts/otel-demo-aegis/templates/otel-collector-configmap.yaml
@@ -1,0 +1,119 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: otel-demo-aegis
+data:
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    exporters:
+      clickhouse:
+        database: {{ .Values.otelCollector.clickhouse.database | quote }}
+        endpoint: {{ .Values.otelCollector.clickhouse.endpoint | quote }}
+        logs_table_name: {{ .Values.otelCollector.clickhouse.logsTableName | quote }}
+        metrics_table_name: {{ .Values.otelCollector.clickhouse.metricsTableName | quote }}
+        traces_table_name: {{ .Values.otelCollector.clickhouse.tracesTableName | quote }}
+        ttl: {{ .Values.otelCollector.clickhouse.ttl | quote }}
+        timeout: {{ .Values.otelCollector.clickhouse.timeout | quote }}
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_elapsed_time: 300s
+          max_interval: 30s
+        sending_queue:
+          enabled: {{ .Values.otelCollector.sendingQueue.enabled }}
+          num_consumers: {{ .Values.otelCollector.sendingQueue.numConsumers }}
+          queue_size: {{ .Values.otelCollector.sendingQueue.queueSize }}
+          blocking: {{ .Values.otelCollector.sendingQueue.blocking }}
+    processors:
+      batch:
+        send_batch_max_size: {{ .Values.otelCollector.batch.sendBatchMaxSize }}
+        send_batch_size: {{ .Values.otelCollector.batch.sendBatchSize }}
+        timeout: {{ .Values.otelCollector.batch.timeout | quote }}
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: {{ .Values.otelCollector.memoryLimiter.limitPercentage }}
+        spike_limit_percentage: {{ .Values.otelCollector.memoryLimiter.spikeLimitPercentage }}
+      k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.start_time
+            - service.name
+            - service.version
+            - service.instance.id
+          labels:
+            - tag_name: app.label.component
+              key: app.kubernetes.io/component
+              from: pod
+            - tag_name: service.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: service.name
+              key: app
+              from: pod
+            - tag_name: service.name
+              key: name
+              from: pod
+          otel_annotations: true
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+          - sources:
+              - from: connection
+      transform/service_namespace:
+        trace_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+        metric_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+        log_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+    connectors:
+      spanmetrics: {}
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+          exporters: [spanmetrics, clickhouse]
+        metrics:
+          receivers: [otlp, spanmetrics]
+          processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+          exporters: [clickhouse]
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+          exporters: [clickhouse]
+{{- end }}

--- a/charts/otel-demo-aegis/templates/otel-collector-deployment.yaml
+++ b/charts/otel-demo-aegis/templates/otel-collector-deployment.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: otel-demo-aegis
+spec:
+  replicas: {{ .Values.otelCollector.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.otelCollector.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.otelCollector.name }}
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/part-of: otel-demo-aegis
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/otel-collector-configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ .Values.otelCollector.name }}
+      containers:
+        - name: otel-collector
+          image: "{{ .Values.otelCollector.image.repository }}:{{ .Values.otelCollector.image.tag }}"
+          imagePullPolicy: {{ .Values.otelCollector.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - --config=/conf/collector.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+          resources:
+            {{- toYaml .Values.otelCollector.resources | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: 4317
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 4317
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Values.otelCollector.name }}
+            items:
+              - key: collector.yaml
+                path: collector.yaml
+{{- end }}

--- a/charts/otel-demo-aegis/templates/otel-collector-service.yaml
+++ b/charts/otel-demo-aegis/templates/otel-collector-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: otel-demo-aegis
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Values.otelCollector.name }}
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+{{- end }}

--- a/charts/otel-demo-aegis/templates/otel-collector-serviceaccount.yaml
+++ b/charts/otel-demo-aegis/templates/otel-collector-serviceaccount.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: otel-demo-aegis
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Values.otelCollector.name }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: otel-demo-aegis
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets", "deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Values.otelCollector.name }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: otel-demo-aegis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Namespace }}-{{ .Values.otelCollector.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.otelCollector.name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/otel-demo-aegis/values.yaml
+++ b/charts/otel-demo-aegis/values.yaml
@@ -1,8 +1,67 @@
-# Cluster-wide OTel collector (otel-kube-stack deployment collector) that the
-# demo's in-namespace collector exports to.
+# Downstream OTel collector that the demo's in-namespace collector exports to.
+# Default points at the per-namespace aegis sidecar collector deployed by this
+# chart (see .Values.otelCollector below) which exports directly to ClickHouse.
+# Override with --set global.clusterCollector.service=<host> (no port) to fall
+# back to a cross-namespace shared cluster collector — typical when
+# otelCollector.enabled=false. Leave the cross-ns FQDN here as a reference:
+#   service: opentelemetry-kube-stack-deployment-otel-demo-collector.monitoring.svc.cluster.local
 global:
   clusterCollector:
-    service: otel-collector.otel.svc.cluster.local
+    service: aegis-otel-collector
+
+# Per-namespace OTel collector sidecar.
+#
+# Deploys a single-replica otel-collector-contrib in the release namespace so
+# each otel-demo install gets its own sending_queue and exports directly to
+# ClickHouse, instead of all namespaces fanning into one shared cluster-wide
+# collector that saturates and silently drops spans (aegis #366, #367).
+#
+# The data path becomes:
+#   demo apps -> demo's in-ns "otel-collector" (otlp/transform/spanmetrics)
+#             -> this chart's "aegis-otel-collector" (k8sattributes/clickhouse)
+#             -> ClickHouse
+#
+# Disable to skip the sidecar — also override .global.clusterCollector.service
+# to point at a shared collector reachable from this namespace.
+otelCollector:
+  enabled: true
+  # Distinct from the upstream demo subchart's own "otel-collector" Deployment
+  # which already exists in the release namespace; collision would break both.
+  name: aegis-otel-collector
+  replicas: 1
+  image:
+    # docker.io/opspai mirror; volces auto-mirrors to
+    # pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib.
+    repository: docker.io/opspai/opentelemetry-collector-contrib
+    tag: "0.142.0"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: 2
+      memory: 4Gi
+  clickhouse:
+    endpoint: "tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000?dial_timeout=10s&compress=lz4&username=default"
+    database: otel
+    tracesTableName: otel_traces
+    metricsTableName: otel_metrics
+    logsTableName: otel_logs
+    ttl: 72h
+    timeout: 30s
+  sendingQueue:
+    enabled: true
+    numConsumers: 10
+    queueSize: 5000
+    blocking: true
+  batch:
+    sendBatchSize: 2000
+    sendBatchMaxSize: 4000
+    timeout: 5s
+  memoryLimiter:
+    limitPercentage: 75
+    spikeLimitPercentage: 15
 
 opentelemetry-demo:
   # Mirror upstream images to opspai dockerhub so the volces auto-mirror


### PR DESCRIPTION
## Summary

Adds a per-namespace OTel collector sidecar to the `otel-demo-aegis` chart, mirroring [OperationsPAI/train-ticket#24](https://github.com/OperationsPAI/train-ticket/pull/24). Each release now ships a single-replica `otel/opentelemetry-collector-contrib:0.142.0` Deployment named `aegis-otel-collector` (distinct from the upstream demo subchart's existing `otel-collector` to avoid name collision in the same namespace) with its own ClusterIP Service, ConfigMap, ServiceAccount, and namespace-prefixed ClusterRole/Binding for the `k8sattributes` processor.

The data path becomes:

```
demo apps -> demo's in-ns "otel-collector"   (otlp/transform/spanmetrics)
          -> "aegis-otel-collector"          (k8sattributes/clickhouse)
          -> ClickHouse (clickstack-clickhouse-clickhouse-headless.monitoring)
```

Default `global.clusterCollector.service` flips from the cross-ns FQDN of the shared `monitoring/opentelemetry-kube-stack-deployment-otel-demo-collector` to the same-ns short DNS `aegis-otel-collector`. Set `otelCollector.enabled=false` and override `global.clusterCollector.service` to fall back to a shared collector.

## Why

A single shared cluster collector serving N `otel-demoN` namespaces saturates its ClickHouse-exporter `sending_queue` and silently drops spans, leaving `abnormal_traces.parquet` empty for downstream `BuildDatapack` windows (refs aegis #366 readiness gap, aegis #367 collector backpressure). Per-namespace collectors give failure isolation, queue independence, and shorter DNS resolution.

## Implementation notes

- **Naming.** The upstream `opentelemetry-demo` subchart already deploys an in-namespace `otel-collector` Deployment / Service. We **chain through it** rather than replacing — that collector keeps doing its postgres/redis/nginx scrapes, http.route transforms, and spanmetrics, then exports OTLP to the new aegis sidecar. The new resource is therefore named `aegis-otel-collector` to avoid colliding with the upstream subchart.
- **Image.** `docker.io/opspai/opentelemetry-collector-contrib:0.142.0` (mirrored today, volces auto-mirrors to `pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib:0.142.0`).
- **`helm template` verification.**
  - The upstream subchart's collector `otlp` exporter renders `endpoint: 'aegis-otel-collector:4317'` (was `otel-collector.otel.svc.cluster.local:4317`).
  - Demo apps' `OTEL_EXPORTER_OTLP_ENDPOINT` continues to point at `http://$(OTEL_COLLECTOR_NAME):4317|4318` with `OTEL_COLLECTOR_NAME=otel-collector` — i.e. unchanged, still hitting the demo's own in-ns collector first. Correct.
  - All new sidecar resources land in the release namespace; `ClusterRole`/`Binding` are prefixed with `{{ .Release.Namespace }}-aegis-otel-collector` for parallel-install safety.
- `helm lint` clean.

## Chart version

`0.1.8` -> `0.1.9`. Publishing (gh-pages branch + OCI push to volces) is intentionally **not** run in this PR — aegis byte-cluster picks up the new version on next reseed.

## Out of scope / follow-ups

- `onlineboutique-aegis` chart in this repo also uses the shared cluster collector and would benefit from the same treatment — left as a separate PR to keep this one focused.

## Refs

- aegis #366 (readiness gap)
- aegis #367 (ts collector backpressure)
- OperationsPAI/train-ticket#24 (same change for ts)

## Test plan

- [ ] `helm template charts/otel-demo-aegis -n otel-demo0` produces all 4 new sidecar resources in `otel-demo0` ns
- [ ] Apply on byte-cluster to a fresh `otel-demoN` namespace; confirm `aegis-otel-collector` Pod becomes Ready
- [ ] Confirm demo collector logs show OTLP export success to `aegis-otel-collector:4317`
- [ ] Confirm spans/metrics/logs land in `monitoring/clickstack-clickhouse` for the new namespace
- [ ] Inject a fault and confirm `abnormal_traces.parquet` is non-empty (the original symptom)
- [ ] Run two parallel installs (`otel-demo0`, `otel-demo1`) and confirm no `ClusterRole exists and cannot be imported` error