### PR TITLE
fix(otel-demo): drop sending_queue.blocking key

### DIFF
--- a/charts/otel-demo-aegis/Chart.yaml
+++ b/charts/otel-demo-aegis/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-demo-aegis
 description: opentelemetry-demo wrapper for aegis. Keeps the demo's in-namespace collector, avoids cluster-scoped RBAC, and forwards OTLP to the cluster collector.
-version: 0.1.9
+version: 0.1.10
 appVersion: "2.2.0"
 dependencies:
 - name: opentelemetry-demo

--- a/charts/otel-demo-aegis/templates/otel-collector-configmap.yaml
+++ b/charts/otel-demo-aegis/templates/otel-collector-configmap.yaml
@@ -35,7 +35,6 @@ data:
           enabled: {{ .Values.otelCollector.sendingQueue.enabled }}
           num_consumers: {{ .Values.otelCollector.sendingQueue.numConsumers }}
           queue_size: {{ .Values.otelCollector.sendingQueue.queueSize }}
-          blocking: {{ .Values.otelCollector.sendingQueue.blocking }}
     processors:
       batch:
         send_batch_max_size: {{ .Values.otelCollector.batch.sendBatchMaxSize }}

--- a/charts/otel-demo-aegis/values.yaml
+++ b/charts/otel-demo-aegis/values.yaml
@@ -54,7 +54,6 @@ otelCollector:
     enabled: true
     numConsumers: 10
     queueSize: 5000
-    blocking: true
   batch:
     sendBatchSize: 2000
     sendBatchMaxSize: 4000


### PR DESCRIPTION
Hot-fix: collector v0.142.0 rejects `blocking: true`. Bumps to 0.1.10.