### PR TITLE
chore(versions): bump sn/media fork SHA to 04e3cb6 (loader offline data-init)

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -6,6 +6,6 @@
 # The chart for each of these systems lives in the fork's gh-pages
 # site, not in this repo — we only own the images.
 hs: 61074ea        # github.com/LGU-SE-Internal/DeathStarBench (hotelReservation)
-sn: 9397c2e        # github.com/LGU-SE-Internal/DeathStarBench (socialNetwork)
-media: 9397c2e     # github.com/LGU-SE-Internal/DeathStarBench (mediaMicroservices)
+sn: 04e3cb6        # github.com/LGU-SE-Internal/DeathStarBench (socialNetwork)
+media: 04e3cb6     # github.com/LGU-SE-Internal/DeathStarBench (mediaMicroservices)
 teastore: 2b3fd43  # github.com/LGU-SE-Internal/TeaStore


### PR DESCRIPTION
Records that the sn + media loader images were rebuilt from LGU-SE-Internal/DeathStarBench@04e3cb6 (PR #62), which bakes aiohttp/curl/nc into the loader so the load-generator data-init initContainer no longer apt/pip-installs from the public internet at pod start (byte-cluster ~17 kB/s egress was blowing the 25-min readiness timeout). Loader images pushed as `20260529-04e3cb6`. 🤖 Generated with [Claude Code](https://claude.com/claude-code)