### PR TITLE
chore(versions): bump sn/media to e7ad889 (enriched OTLP logs)

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -6,6 +6,6 @@
 # The chart for each of these systems lives in the fork's gh-pages
 # site, not in this repo — we only own the images.
 hs: 61074ea        # github.com/LGU-SE-Internal/DeathStarBench (hotelReservation)
-sn: 04e3cb6        # github.com/LGU-SE-Internal/DeathStarBench (socialNetwork)
-media: 04e3cb6     # github.com/LGU-SE-Internal/DeathStarBench (mediaMicroservices)
+sn: e7ad889        # github.com/LGU-SE-Internal/DeathStarBench (socialNetwork)
+media: e7ad889     # github.com/LGU-SE-Internal/DeathStarBench (mediaMicroservices)
 teastore: 2b3fd43  # github.com/LGU-SE-Internal/TeaStore

--- a/versions.yaml
+++ b/versions.yaml
@@ -6,6 +6,6 @@
 # The chart for each of these systems lives in the fork's gh-pages
 # site, not in this repo — we only own the images.
 hs: 61074ea        # github.com/LGU-SE-Internal/DeathStarBench (hotelReservation)
-sn: 9397c2e        # github.com/LGU-SE-Internal/DeathStarBench (socialNetwork)
-media: 9397c2e     # github.com/LGU-SE-Internal/DeathStarBench (mediaMicroservices)
+sn: 04e3cb6        # github.com/LGU-SE-Internal/DeathStarBench (socialNetwork)
+media: 04e3cb6     # github.com/LGU-SE-Internal/DeathStarBench (mediaMicroservices)
 teastore: 2b3fd43  # github.com/LGU-SE-Internal/TeaStore


### PR DESCRIPTION
Bumps sn+media fork SHA to e7ad889 (LGU-SE-Internal/DeathStarBench#64): adds INFO logs to all media/sn C++ RPC handlers so normal-window OTLP logs are non-empty. Fixes RCABench datapack build failing on empty normal_logs.parquet. Images rebuilt+pushed from this SHA.