### PR TITLE
fix(onlineboutique-aegis): deploy per-ns OTel collector, volces images, drop dead otel.svc shim

### DIFF
--- a/charts/onlineboutique-aegis/Chart.yaml
+++ b/charts/onlineboutique-aegis/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: onlineboutique-aegis
 description: onlineboutique + aegis-cluster OTel shim (wrapper chart). Proof of concept for OperationsPAI/benchmark-charts (issue #92).
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.10.5"
 dependencies:
 - name: onlineboutique

--- a/charts/onlineboutique-aegis/charts/onlineboutique/templates/cartservice.yaml
+++ b/charts/onlineboutique-aegis/charts/onlineboutique/templates/cartservice.yaml
@@ -252,7 +252,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
         {{- if .Values.cartDatabase.inClusterRedis.publicRepository }}
-        image: redis:alpine@sha256:2afba59292f25f5d1af200496db41bea2c6c816b059f57ae74703a50a03a27d0
+        image: pair-cn-shanghai.cr.volces.com/library/redis@sha256:2afba59292f25f5d1af200496db41bea2c6c816b059f57ae74703a50a03a27d0
         {{- else }}
         image: {{ .Values.images.repository }}/redis:alpine
         {{- end }}

--- a/charts/onlineboutique-aegis/charts/onlineboutique/templates/loadgenerator.yaml
+++ b/charts/onlineboutique-aegis/charts/onlineboutique/templates/loadgenerator.yaml
@@ -92,7 +92,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: busybox:latest@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f
+        image: pair-cn-shanghai.cr.volces.com/library/busybox@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f
         env:
         - name: FRONTEND_ADDR
           value: "{{ .Values.frontend.name }}:80"

--- a/charts/onlineboutique-aegis/templates/otel-collector-configmap.yaml
+++ b/charts/onlineboutique-aegis/templates/otel-collector-configmap.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: onlineboutique-aegis
+data:
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    exporters:
+      clickhouse:
+        database: {{ .Values.otelCollector.clickhouse.database | quote }}
+        endpoint: {{ .Values.otelCollector.clickhouse.endpoint | quote }}
+        logs_table_name: {{ .Values.otelCollector.clickhouse.logsTableName | quote }}
+        metrics_table_name: {{ .Values.otelCollector.clickhouse.metricsTableName | quote }}
+        traces_table_name: {{ .Values.otelCollector.clickhouse.tracesTableName | quote }}
+        ttl: {{ .Values.otelCollector.clickhouse.ttl | quote }}
+        timeout: {{ .Values.otelCollector.clickhouse.timeout | quote }}
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_elapsed_time: 300s
+          max_interval: 30s
+        sending_queue:
+          enabled: {{ .Values.otelCollector.sendingQueue.enabled }}
+          num_consumers: {{ .Values.otelCollector.sendingQueue.numConsumers }}
+          queue_size: {{ .Values.otelCollector.sendingQueue.queueSize }}
+    processors:
+      batch:
+        send_batch_max_size: {{ .Values.otelCollector.batch.sendBatchMaxSize }}
+        send_batch_size: {{ .Values.otelCollector.batch.sendBatchSize }}
+        timeout: {{ .Values.otelCollector.batch.timeout | quote }}
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: {{ .Values.otelCollector.memoryLimiter.limitPercentage }}
+        spike_limit_percentage: {{ .Values.otelCollector.memoryLimiter.spikeLimitPercentage }}
+      k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.start_time
+            - service.name
+            - service.version
+            - service.instance.id
+          labels:
+            - tag_name: app.label.component
+              key: app.kubernetes.io/component
+              from: pod
+            - tag_name: service.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: service.name
+              key: app
+              from: pod
+            - tag_name: service.name
+              key: name
+              from: pod
+          otel_annotations: true
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+          - sources:
+              - from: connection
+      transform/service_namespace:
+        trace_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+        metric_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+        log_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+    connectors:
+      spanmetrics: {}
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+          exporters: [spanmetrics, clickhouse]
+        metrics:
+          receivers: [otlp, spanmetrics]
+          processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+          exporters: [clickhouse]
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+          exporters: [clickhouse]
+{{- end }}

--- a/charts/onlineboutique-aegis/templates/otel-collector-deployment.yaml
+++ b/charts/onlineboutique-aegis/templates/otel-collector-deployment.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: onlineboutique-aegis
+spec:
+  replicas: {{ .Values.otelCollector.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.otelCollector.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.otelCollector.name }}
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/part-of: onlineboutique-aegis
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/otel-collector-configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ .Values.otelCollector.name }}
+      containers:
+        - name: otel-collector
+          image: "{{ .Values.otelCollector.image.repository }}:{{ .Values.otelCollector.image.tag }}"
+          imagePullPolicy: {{ .Values.otelCollector.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - --config=/conf/collector.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+          resources:
+            {{- toYaml .Values.otelCollector.resources | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: 4317
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 4317
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Values.otelCollector.name }}
+            items:
+              - key: collector.yaml
+                path: collector.yaml
+{{- end }}

--- a/charts/onlineboutique-aegis/templates/otel-collector-service.yaml
+++ b/charts/onlineboutique-aegis/templates/otel-collector-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: onlineboutique-aegis
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Values.otelCollector.name }}
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+{{- end }}

--- a/charts/onlineboutique-aegis/templates/otel-collector-serviceaccount.yaml
+++ b/charts/onlineboutique-aegis/templates/otel-collector-serviceaccount.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: onlineboutique-aegis
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Values.otelCollector.name }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: onlineboutique-aegis
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets", "deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Values.otelCollector.name }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: onlineboutique-aegis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Namespace }}-{{ .Values.otelCollector.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.otelCollector.name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/onlineboutique-aegis/templates/otel-shim.yaml
+++ b/charts/onlineboutique-aegis/templates/otel-shim.yaml
@@ -1,8 +1,7 @@
-# Static ExternalName Service replacing what the subchart's
-# opentelemetry-collector.yaml would have deployed. Services in this
-# release are injected with COLLECTOR_SERVICE_ADDR=opentelemetrycollector:4317
-# (gated by onlineboutique.opentelemetryCollector.create=true); this Service
-# resolves that name to the cluster-wide collector.
+# ExternalName Service that resolves the subchart's injected
+# COLLECTOR_SERVICE_ADDR=opentelemetrycollector:4317 to the per-namespace
+# aegis-otel-collector deployed by this chart (otel-collector-*.yaml). Override
+# clusterCollector.service to point elsewhere; default is the in-ns collector.
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   type: ExternalName
-  externalName: {{ .Values.clusterCollector.service }}
+  externalName: {{ .Values.clusterCollector.service | default (printf "%s.%s.svc.cluster.local" .Values.otelCollector.name .Release.Namespace) }}
   ports:
   - name: otlp-grpc
     port: 4317

--- a/charts/onlineboutique-aegis/values.yaml
+++ b/charts/onlineboutique-aegis/values.yaml
@@ -33,7 +33,7 @@ otelCollector:
   name: aegis-otel-collector
   replicas: 1
   image:
-    repository: docker.io/opspai/opentelemetry-collector-contrib
+    repository: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib
     tag: 0.142.0
     pullPolicy: IfNotPresent
   resources:

--- a/charts/onlineboutique-aegis/values.yaml
+++ b/charts/onlineboutique-aegis/values.yaml
@@ -1,14 +1,19 @@
 clusterCollector:
-  service: otel-collector.otel.svc.cluster.local
+  # Empty -> otel-shim defaults to the in-ns aegis-otel-collector. Override to
+  # send to an external/shared collector instead.
+  service: ""
 
 onlineboutique:
   images:
-    repository: us-central1-docker.pkg.dev/google-samples/microservices-demo
+    repository: pair-cn-shanghai.cr.volces.com/opspai
     tag: ""
   opentelemetryCollector:
     create: true
     name: opentelemetrycollector
     projectId: "PROJECT_ID"
+  # tracing:true is what injects ENABLE_TRACING + COLLECTOR_SERVICE_ADDR into the
+  # services (the OTel path, NOT just GCP). With opentelemetryCollector.create=true
+  # traces go to the in-ns collector, not GCP, so the PROJECT_ID placeholder is inert.
   googleCloudOperations:
     profiler: false
     tracing: true
@@ -19,3 +24,41 @@ onlineboutique:
   shoppingAssistantService: { create: false }
   frontend:
     externalService: false   # kind cluster has no LB provider; skip LoadBalancer svc
+
+# Per-namespace OTel collector (mirrors otel-demo-aegis): ob services
+# -> opentelemetrycollector ExternalName -> this in-ns aegis-otel-collector
+# -> ClickHouse. Replaces the dead otel-collector.otel.svc shim.
+otelCollector:
+  enabled: true
+  name: aegis-otel-collector
+  replicas: 1
+  image:
+    repository: docker.io/opspai/opentelemetry-collector-contrib
+    tag: 0.142.0
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: 2
+      memory: 4Gi
+  clickhouse:
+    endpoint: tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000?dial_timeout=10s&compress=lz4&username=default
+    database: otel
+    tracesTableName: otel_traces
+    metricsTableName: otel_metrics
+    logsTableName: otel_logs
+    ttl: 72h
+    timeout: 30s
+  sendingQueue:
+    enabled: true
+    numConsumers: 10
+    queueSize: 5000
+  batch:
+    sendBatchSize: 2000
+    sendBatchMaxSize: 4000
+    timeout: 5s
+  memoryLimiter:
+    limitPercentage: 75
+    spikeLimitPercentage: 15


### PR DESCRIPTION
## Why
`onlineboutique-aegis` wired the demo services' `COLLECTOR_SERVICE_ADDR=opentelemetrycollector:4317` to an ExternalName → `otel-collector.otel.svc.cluster.local`, but the `otel` namespace does not exist on byte-cluster → **all telemetry dropped → empty datapacks** (a fresh ob0 emitted 0 spans to ClickHouse). The chart also defaulted images to `us-central1-docker.pkg.dev` (GAR), unreachable on byte-cluster → ImagePullBackOff.

## What
Mirror the sibling `otel-demo-aegis` chart, which already does per-ns collectors correctly:
- **Add 4 collector templates** (`otel-collector-{configmap,deployment,service,serviceaccount}.yaml`) deploying an in-namespace `aegis-otel-collector` (otel-collector-contrib: otlp receiver → k8sattributes + transform/service_namespace → ClickHouse exporter `clickstack-clickhouse-clickhouse-headless.monitoring:9000`). Per-ns RBAC named `{{ .Release.Namespace }}-aegis-otel-collector` so co-installed namespaces don't collide.
- **Repoint the `opentelemetrycollector` ExternalName** at `aegis-otel-collector.{{ .Release.Namespace }}.svc.cluster.local` (otel-shim now defaults there when `clusterCollector.service` is empty).
- **Default images to the volces mirror** `pair-cn-shanghai.cr.volces.com/opspai`.
- Keep `googleCloudOperations.tracing: true` (that's what injects ENABLE_TRACING + COLLECTOR_SERVICE_ADDR — the OTel path, not just GCP; with `opentelemetryCollector.create=true` traces go to the collector, the PROJECT_ID placeholder is inert).
- Bump chart `0.1.1 → 0.1.2`.

## Verified
- `helm lint` clean; `helm template --namespace ob0` renders the full `aegis-otel-collector` set + ExternalName → `aegis-otel-collector.ob0.svc`, image = volces, ENABLE_TRACING/COLLECTOR_SERVICE_ADDR present (7/8 refs).
- A hand-applied equivalent (copied from a working sn0 per-ns collector) made the live ob0 emit **6800+ spans/2min** to ClickHouse across 7 services incl. the frontend entrance.
- Chart `0.1.2` published to `oci://docker.io/opspai` (volces-mirrored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)