### PR TITLE
feat(otel-demo): add CPU limits to service pods so cpu_stress is effective

### DIFF
--- a/charts/otel-demo-aegis/Chart.yaml
+++ b/charts/otel-demo-aegis/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-demo-aegis
 description: opentelemetry-demo wrapper for aegis. Keeps the demo's in-namespace collector, avoids cluster-scoped RBAC, and forwards OTLP to the cluster collector.
-version: 0.1.10
+version: 0.1.11
 appVersion: "2.2.0"
 dependencies:
 - name: opentelemetry-demo

--- a/charts/otel-demo-aegis/values.yaml
+++ b/charts/otel-demo-aegis/values.yaml
@@ -75,25 +75,92 @@ opentelemetry-demo:
         tag: "2.2.0"
       initContainers: []
     accounting:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
       initContainers:
         - name: wait-for-kafka
           image: docker.io/opspai/busybox:latest
           command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
     cart:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
       initContainers:
         - name: wait-for-valkey-cart
           image: docker.io/opspai/busybox:latest
           command: ["sh", "-c", "until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep 2; done;"]
     checkout:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
       initContainers:
         - name: wait-for-kafka
           image: docker.io/opspai/busybox:latest
           command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
     fraud-detection:
+      resources:
+        requests: {cpu: 50m, memory: 384Mi}
+        limits: {cpu: 500m, memory: 1331Mi}
       initContainers:
         - name: wait-for-kafka
           image: docker.io/opspai/busybox:latest
           command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+    # CPU limits added so cpu_stress has a ceiling to throttle against (aegis #563);
+    # without a limit a 4-worker stress is a no-op. mem right-sized to ~peak+1Gi so
+    # normal/burst traffic never OOMs (the stress fault, not the limit, does the biting).
+    ad:
+      resources:
+        requests: {cpu: 50m, memory: 384Mi}
+        limits: {cpu: 500m, memory: 1280Mi}
+    currency:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    email:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    frontend:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    frontend-proxy:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    image-provider:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    llm:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    payment:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    product-catalog:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 600m, memory: 1Gi}
+    product-reviews:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    quote:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    recommendation:
+      resources:
+        requests: {cpu: 50m, memory: 256Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    shipping:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
     flagd:
       initContainers:
         - name: init-config


### PR DESCRIPTION
## Why

Durable fix for OperationsPAI/aegis#563. Today every `otel-demo` service pod has a **memory limit but NO cpu limit** — so a `cpu_stress` fault has no ceiling to throttle against and measures **~0% effect**. This is the root cause of `cpu_stress=0%` on otel-demo.

## What

Add resource limits to all 17 chaos-target service components in the `otel-demo-aegis` wrapper (`opentelemetry-demo.components.<svc>.resources`):

- **CPU limit `500m`** on every service pod (`product-catalog` `600m`, the lone CPU mover at p90 79m), **CPU request `50m`**.
- **Memory right-sized** to `~peak + 1Gi` so normal/burst traffic never throttles or OOMs: `ad` `1280Mi`, `fraud-detection` `1331Mi`, all others `1Gi` (replacing the old tight `mem_lim≈mem_req` ~20-500Mi values).

Sizing follows the GENEROUS principle from aegis#563: the limit only needs to be comfortably above normal+burst and finite — a 4-worker `cpu_stress` (~3.6 cores demanded) overshoots any reasonable limit, so 500m is trivially breached while never biting baseline traffic.

Infra left **untouched**: `aegis-otel-collector`, the demo `otel-collector`, `load-generator`, `kafka`, `valkey-cart`, `postgresql`, `flagd`.

## Proven

We already verified the mechanism on otel-demo: a **500m CPU limit on `frontend`** let `cpu_stress` throttle it to 500m and degraded **frontend p95 21.7→97ms** and **user-journey p95 49.7→153ms**. This PR makes that durable in the chart.

## Per-service values

| component | cpu req | cpu lim | mem req | mem lim |
|---|---|---|---|---|
| ad | 50m | 500m | 384Mi | 1280Mi |
| fraud-detection | 50m | 500m | 384Mi | 1331Mi |
| recommendation | 50m | 500m | 256Mi | 1Gi |
| product-catalog | 50m | 600m | 128Mi | 1Gi |
| accounting, cart, checkout, currency, email, frontend, frontend-proxy, image-provider, llm, payment, product-reviews, quote, shipping | 50m | 500m | 128Mi | 1Gi |

## Notes

- The `otel-demo` subchart has **no `default.resources` merge** — its template renders each component's `.resources` standalone — so resources are set **per service component**, not via a single `default` block.
- Chart `version` bumped `0.1.10` → `0.1.11`; on merge the `release` workflow packages + `helm push`es to `oci://registry-1.docker.io/opspai`, which the volces registry auto-mirrors.
- Catalog stress-point coverage broadening (manifestgen) is a separate follow-up tracked in aegis#563 — limits alone are this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)