### PR TITLE
fix(otel-collector): create_schema=false to prevent crash-loop on ClickHouse connection reset

### DIFF
--- a/charts/otel-demo-aegis/Chart.yaml
+++ b/charts/otel-demo-aegis/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-demo-aegis
 description: opentelemetry-demo wrapper for aegis. Keeps the demo's in-namespace collector, avoids cluster-scoped RBAC, and forwards OTLP to the cluster collector.
-version: 0.1.12
+version: 0.1.13
 appVersion: "2.2.0"
 dependencies:
 - name: opentelemetry-demo

--- a/charts/otel-demo-aegis/Chart.yaml
+++ b/charts/otel-demo-aegis/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-demo-aegis
 description: opentelemetry-demo wrapper for aegis. Keeps the demo's in-namespace collector, avoids cluster-scoped RBAC, and forwards OTLP to the cluster collector.
-version: 0.1.10
+version: 0.1.11
 appVersion: "2.2.0"
 dependencies:
 - name: opentelemetry-demo

--- a/charts/otel-demo-aegis/Chart.yaml
+++ b/charts/otel-demo-aegis/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-demo-aegis
 description: opentelemetry-demo wrapper for aegis. Keeps the demo's in-namespace collector, avoids cluster-scoped RBAC, and forwards OTLP to the cluster collector.
-version: 0.1.11
+version: 0.1.12
 appVersion: "2.2.0"
 dependencies:
 - name: opentelemetry-demo

--- a/charts/otel-demo-aegis/templates/otel-collector-configmap.yaml
+++ b/charts/otel-demo-aegis/templates/otel-collector-configmap.yaml
@@ -21,6 +21,7 @@ data:
       clickhouse:
         database: {{ .Values.otelCollector.clickhouse.database | quote }}
         endpoint: {{ .Values.otelCollector.clickhouse.endpoint | quote }}
+        create_schema: false
         logs_table_name: {{ .Values.otelCollector.clickhouse.logsTableName | quote }}
         metrics_table_name: {{ .Values.otelCollector.clickhouse.metricsTableName | quote }}
         traces_table_name: {{ .Values.otelCollector.clickhouse.tracesTableName | quote }}

--- a/charts/otel-demo-aegis/templates/otel-collector-configmap.yaml
+++ b/charts/otel-demo-aegis/templates/otel-collector-configmap.yaml
@@ -100,16 +100,14 @@ data:
           - context: resource
             statements:
               - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
-    connectors:
-      spanmetrics: {}
     service:
       pipelines:
         traces:
           receivers: [otlp]
           processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
-          exporters: [spanmetrics, clickhouse]
+          exporters: [clickhouse]
         metrics:
-          receivers: [otlp, spanmetrics]
+          receivers: [otlp]
           processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
           exporters: [clickhouse]
         logs:

--- a/charts/otel-demo-aegis/values.yaml
+++ b/charts/otel-demo-aegis/values.yaml
@@ -75,25 +75,92 @@ opentelemetry-demo:
         tag: "2.2.0"
       initContainers: []
     accounting:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
       initContainers:
         - name: wait-for-kafka
           image: docker.io/opspai/busybox:latest
           command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
     cart:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
       initContainers:
         - name: wait-for-valkey-cart
           image: docker.io/opspai/busybox:latest
           command: ["sh", "-c", "until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep 2; done;"]
     checkout:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
       initContainers:
         - name: wait-for-kafka
           image: docker.io/opspai/busybox:latest
           command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
     fraud-detection:
+      resources:
+        requests: {cpu: 50m, memory: 384Mi}
+        limits: {cpu: 500m, memory: 1331Mi}
       initContainers:
         - name: wait-for-kafka
           image: docker.io/opspai/busybox:latest
           command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+    # CPU limits added so cpu_stress has a ceiling to throttle against (aegis #563);
+    # without a limit a 4-worker stress is a no-op. mem right-sized to ~peak+1Gi so
+    # normal/burst traffic never OOMs (the stress fault, not the limit, does the biting).
+    ad:
+      resources:
+        requests: {cpu: 50m, memory: 384Mi}
+        limits: {cpu: 500m, memory: 1280Mi}
+    currency:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    email:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    frontend:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    frontend-proxy:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    image-provider:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    llm:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    payment:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    product-catalog:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 600m, memory: 1Gi}
+    product-reviews:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    quote:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    recommendation:
+      resources:
+        requests: {cpu: 50m, memory: 256Mi}
+        limits: {cpu: 500m, memory: 1Gi}
+    shipping:
+      resources:
+        requests: {cpu: 50m, memory: 128Mi}
+        limits: {cpu: 500m, memory: 1Gi}
     flagd:
       initContainers:
         - name: init-config


### PR DESCRIPTION
## Root cause

The ClickHouse exporter defaults to `create_schema: true`, which runs `CREATE DATABASE` / `CREATE TABLE` DDL on every collector startup. When ClickHouse momentarily resets the TCP connection during this handshake, the exporter fatally exits:

```
cannot start pipelines: failed to start "clickhouse" exporter: create database: handshake: ... connection reset by peer
```

This causes the per-namespace OTel collector pod to crash-loop, blanking traces/metrics/logs until the connection stays stable long enough for DDL to complete.

## Fix

Set `create_schema: false` in the `clickhouse:` exporter block. The schema (otel_traces / otel_metrics_* / otel_logs tables) already exists — it is shared by all per-namespace collectors and created once at cluster bootstrap. Skipping DDL on startup removes the fatal failure path entirely; the exporter immediately proceeds to INSERT-only mode.

Chart bumped: `0.1.11` → `0.1.12`.

## Second commit: remove spanmetrics connector

The `spanmetrics` connector (connector → traces exporter + metrics receiver) generated span-derived metrics and forwarded them to ClickHouse, accounting for ~28% of CH ingest with no downstream consumer. This commit removes it entirely: drops the `connectors:` block, removes `spanmetrics` from `service.pipelines.traces.exporters`, and removes it from `service.pipelines.metrics.receivers`. Chart bumped `0.1.12` → `0.1.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)